### PR TITLE
Split keyboard support

### DIFF
--- a/src/ja_romaji.qml
+++ b/src/ja_romaji.qml
@@ -1,9 +1,38 @@
+/*
+ * Copyright (C) 2012-2013 Jolla ltd and/or its subsidiary(-ies). All rights reserved.
+ *
+ * Contact: Pekka Vuorela <pekka.vuorela@jollamobile.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * Neither the name of Jolla Ltd nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 
 import QtQuick 2.0
-import Sailfish.Silica 1.0
 import ".."
 
 KeyboardLayout {
+    splitSupported: true
+
     KeyboardRow {
         CharacterKey { caption: "q"; captionShifted: "Q"; symView: "1"; symView2: "€" }
         CharacterKey { caption: "w"; captionShifted: "W"; symView: "2"; symView2: "£" }
@@ -11,13 +40,15 @@ KeyboardLayout {
         CharacterKey { caption: "r"; captionShifted: "R"; symView: "4"; symView2: "¥" }
         CharacterKey { caption: "t"; captionShifted: "T"; symView: "5"; symView2: "₹"; accents: "tþ"; accentsShifted: "TÞ" }
         CharacterKey { caption: "y"; captionShifted: "Y"; symView: "6"; symView2: "%"; accents: "yý¥"; accentsShifted: "YÝ¥" }
-        CharacterKey { caption: "u"; captionShifted: "U"; symView: "7"; symView2: "<"; accents: "uûùúü"; accentsShifted: "UÛÙÚÜ" }
+        CharacterKey { caption: "u"; captionShifted: "U"; symView: "7"; symView2: "<"; accents: "uűûùúü"; accentsShifted: "UŰÛÙÚÜ" }
         CharacterKey { caption: "i"; captionShifted: "I"; symView: "8"; symView2: ">"; accents: "iîïìí"; accentsShifted: "IÎÏÌÍ" }
-        CharacterKey { caption: "o"; captionShifted: "O"; symView: "9"; symView2: "["; accents: "oöôòó"; accentsShifted: "OÖÔÒÓ" }
+        CharacterKey { caption: "o"; captionShifted: "O"; symView: "9"; symView2: "["; accents: "oőøöôòó"; accentsShifted: "OŐØÖÔÒÓ" }
         CharacterKey { caption: "p"; captionShifted: "P"; symView: "0"; symView2: "]" }
     }
 
     KeyboardRow {
+        splitIndex: 5
+
         CharacterKey { caption: "a"; captionShifted: "A"; symView: "*"; symView2: "`"; accents: "aäàâáãå"; accentsShifted: "AÄÀÂÁÃÅ"}
         CharacterKey { caption: "s"; captionShifted: "S"; symView: "#"; symView2: "^"; accents: "sß$"; accentsShifted: "S$" }
         CharacterKey { caption: "d"; captionShifted: "D"; symView: "+"; symView2: "|"; accents: "dð"; accentsShifted: "DÐ" }
@@ -27,11 +58,13 @@ KeyboardLayout {
         CharacterKey { caption: "j"; captionShifted: "J"; symView: ")"; symView2: "}" }
         CharacterKey { caption: "k"; captionShifted: "K"; symView: "!"; symView2: "¡" }
         CharacterKey { caption: "l"; captionShifted: "L"; symView: "?"; symView2: "¿" }
-        CharacterKey { caption: "ー"; } //captionShifted: "L"; symView: "?"; symView2: "¿" }
+        CharacterKey { caption: "ー"; } // captionShifted: "L"; symView: "?"; symView2: "¿" }
     }
 
     KeyboardRow {
-        ShiftKey { }
+        splitIndex: 5
+
+        ShiftKey {}
 
         CharacterKey { caption: "z"; captionShifted: "Z"; symView: "@"; symView2: "«" }
         CharacterKey { caption: "x"; captionShifted: "X"; symView: "&"; symView2: "»" }
@@ -44,5 +77,5 @@ KeyboardLayout {
         BackspaceKey {}
     }
 
-    SpacebarRow { }
+    SpacebarRow {}
 }

--- a/src/ja_romaji.qml
+++ b/src/ja_romaji.qml
@@ -31,6 +31,7 @@ import QtQuick 2.0
 import ".."
 
 KeyboardLayout {
+    type: "japan_romaji_anthy"
     splitSupported: true
 
     KeyboardRow {
@@ -79,8 +80,4 @@ KeyboardLayout {
 
     SpacebarRow {}
 
-    type: "custom"
-    Component.onCompleted: {
-        keyboard.autocaps = false
-     }
 }

--- a/src/ja_romaji.qml
+++ b/src/ja_romaji.qml
@@ -78,4 +78,9 @@ KeyboardLayout {
     }
 
     SpacebarRow {}
+
+    type: "custom"
+    Component.onCompleted: {
+        keyboard.autocaps = false
+     }
 }

--- a/src/ja_romaji.qml
+++ b/src/ja_romaji.qml
@@ -58,7 +58,7 @@ KeyboardLayout {
         CharacterKey { caption: "j"; captionShifted: "J"; symView: ")"; symView2: "}" }
         CharacterKey { caption: "k"; captionShifted: "K"; symView: "!"; symView2: "¡" }
         CharacterKey { caption: "l"; captionShifted: "L"; symView: "?"; symView2: "¿" }
-        CharacterKey { caption: "ー"; } // captionShifted: "L"; symView: "?"; symView2: "¿" }
+        CharacterKey { caption: "ー"; captionShifted: "～"; symView: "・"; symView2: "…" }
     }
 
     KeyboardRow {

--- a/src/ja_romaji/JaInputHandler.qml
+++ b/src/ja_romaji/JaInputHandler.qml
@@ -201,6 +201,71 @@ InputHandler {
         }
     }
 
+    verticalItem: Component {
+        Item {
+            id: verticalContainer
+
+            SilicaListView {
+                id: verticalList
+
+                model: anthy.candidates
+                anchors.fill: parent
+                clip: true
+                header: Component {
+                    PasteButtonVertical {
+                        visible: Clipboard.hasText
+                        width: verticalList.width
+                        height: visible ? geometry.keyHeightLandscape : 0
+                        popupParent: verticalContainer
+                        popupAnchor: 2 // center
+
+                        onClicked: {
+                            commit(preedit)
+                            MInputMethodQuick.sendCommit(Clipboard.text)
+                        }
+                    }
+                }
+
+                delegate: BackgroundItem {
+                    onClicked: accept(model.index)
+                    width: parent.width
+                    height: geometry.keyHeightLandscape // assuming landscape!
+
+                    Text {
+                        width: parent.width
+                        horizontalAlignment: Text.AlignHCenter
+                        anchors.verticalCenter: parent.verticalCenter
+                        color: index === 0 ? Theme.highlightColor : Theme.primaryColor
+                        font.pixelSize: Theme.fontSizeSmall
+                        fontSizeMode: Text.HorizontalFit
+//                        textFormat: Text.StyledText
+                        text: model.text
+                    }
+                }
+
+                Connections {
+                    target: anthy
+                    onCandidatesUpdated: {
+                        if (!clipboardChange.running) {
+                            verticalList.positionViewAtIndex(0, ListView.Beginning)
+                        }
+                    }
+                }
+                Connections {
+                    target: Clipboard
+                    onTextChanged: {
+                        verticalList.positionViewAtBeginning()
+                        clipboardChange.restart()
+                    }
+                }
+                Timer {
+                    id: clipboardChange
+                    interval: 1000
+                }
+            }
+        }
+    }
+
     function handleKeyClick() {
         var handled = false
         keyboard.expandedPaste = false


### PR DESCRIPTION
Made it possible to use split keyboard supported on Sailfish OS 1.1.4.29.
Changed file made from 1.1.4.29 stock English keyboard so some other changes came from it.